### PR TITLE
Release 0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jade-ext",
-  "version": "0.0.7-10",
+  "version": "0.0.7",
   "author": "Anatoliy C.",
   "description": "CompoundJS adapter for jade templating engine",
   "main": "index.js",


### PR DESCRIPTION
npm3 cannot handle 0.0.7-10 (see https://github.com/npm/npm/issues/10641) and it's been stable for 2.5 years, so why not release 0.0.7?
